### PR TITLE
Use ignorePaths instead of ignoreNodeModules

### DIFF
--- a/packages/renovate-config-default/package.json
+++ b/packages/renovate-config-default/package.json
@@ -23,7 +23,7 @@
     },
     "includeNodeModules": {
       "description": "Include <code>package.json</code> files found within <code>node_modules</code> folders",
-      "ignoreNodeModules": false
+      "ignorePaths": ["node_modules/"]
     },
     "pinVersions": {
       "description": "Use version pinning (maintain a single version only and not semver ranges)",

--- a/packages/renovate-config-default/package.json
+++ b/packages/renovate-config-default/package.json
@@ -23,7 +23,7 @@
     },
     "includeNodeModules": {
       "description": "Include <code>package.json</code> files found within <code>node_modules</code> folders",
-      "ignorePaths": ["node_modules/"]
+      "ignorePaths": []
     },
     "pinVersions": {
       "description": "Use version pinning (maintain a single version only and not semver ranges)",


### PR DESCRIPTION
Since the latter is deprecated:
https://github.com/renovateapp/renovate/blob/48a2d2de8e2389b2b58c36d1dc510c6ecc488046/lib/config/migration.js#L75-L78