### PR TITLE
feat: monorepo preset for `@ngrx`-scoped packages

### DIFF
--- a/packages/renovate-config-monorepo/package.json
+++ b/packages/renovate-config-monorepo/package.json
@@ -314,6 +314,15 @@
         "^@neutrinojs/"
       ]
     },
+    "ngrx": {
+      "description": "ngrx monorepo",
+      "packageNames": [
+        "ngrx"
+      ],
+      "packagePatterns": [
+        "^@ngrx/"
+      ]
+    },
     "pouchdb": {
       "description": "pouchdb monorepo",
       "packageNames": [


### PR DESCRIPTION
Source code hosted at https://github.com/ngrx/platform/tree/master/modules