### PR TITLE
Add DefinitelyTyped to monorepo list.

### DIFF
--- a/packages/renovate-config-group/package.json
+++ b/packages/renovate-config-group/package.json
@@ -52,6 +52,12 @@
         }
       ]
     },
+    "definitelyTyped": {
+      "groupName": "definitelyTyped",
+      "packagePatterns": [
+        "^@types/"
+      ]
+    },
     "gatsbyMonorepo": {
       "packageRules": [
         {

--- a/packages/renovate-config-group/package.json
+++ b/packages/renovate-config-group/package.json
@@ -7,7 +7,7 @@
   "bugs": {
     "url": "https://github.com/singapore/renovate-config/issues"
   },
-  "version": "0.2.0",
+  "version": "0.2.1",
   "renovate-config": {
     "all": {
       "description": "Group all updates together",

--- a/packages/renovate-config-group/static-groups.js
+++ b/packages/renovate-config-group/static-groups.js
@@ -6,6 +6,10 @@ module.exports = {
       enabled: false,
     },
   },
+  definitelyTyped: {
+    groupName: 'definitelyTyped',
+    packagePatterns: ['^@types/'],
+  },
   linters: {
     extends: 'packages:linters',
     groupName: 'linters',


### PR DESCRIPTION
Added definition to `renovate-config-monorepo/generate.js`, then ran
```
node renovate-config-monorepo/generate.js
node renovate-config-group/generate.js
```

Ref:
http://definitelytyped.org/
https://www.npmjs.com/~types
https://www.npmjs.com/search?q=%40types