### PR TITLE
feat: add @commitlint monorepo

### DIFF
--- a/packages/renovate-config-group/package.json
+++ b/packages/renovate-config-group/package.json
@@ -60,6 +60,15 @@
         }
       ]
     },
+    "commitlintMonorepo": {
+      "packageRules": [
+        {
+          "description": "Group packages from commitlint monorepo together",
+          "extends": "monorepo:commitlint",
+          "groupName": "commitlint monorepo"
+        }
+      ]
+    },
     "definitelyTyped": {
       "description": "Group all @types packages together",
       "packageRules": [
@@ -109,6 +118,7 @@
         "group:angular1Monorepo",
         "group:babelMonorepo",
         "group:babel6Monorepo",
+        "group:commitlintMonorepo",
         "group:gatsbyMonorepo",
         "group:jestMonorepo",
         "group:lodashMonorepo",

--- a/packages/renovate-config-monorepo/generate.js
+++ b/packages/renovate-config-monorepo/generate.js
@@ -24,6 +24,10 @@ const staticSources = {
       'angular-touch',
     ],
   },
+  commitlint: {
+    packageNames: ['commitlint'],
+    packagePatterns: ['^@commitlint/'],
+  },
   lodash: {
     packageNames: ['babel-plugin-lodash', 'lodash-webpack-plugin', 'lodash-es'],
     packagePatterns: ['^lodash'],

--- a/packages/renovate-config-monorepo/package.json
+++ b/packages/renovate-config-monorepo/package.json
@@ -246,6 +246,15 @@
         "babel-types"
       ]
     },
+    "commitlint": {
+      "description": "commitlint monorepo",
+      "packageNames": [
+        "commitlint"
+      ],
+      "packagePatterns": [
+        "^@commitlint/"
+      ]
+    },
     "gatsby": {
       "description": "gatsby monorepo",
       "packageNames": [


### PR DESCRIPTION
Adds the `@commitlint` package pattern to the monorepo package.
The group package is also updated to reflect this change.

`@commitlint` refers to the packages at https://github.com/marionebl/commitlint/ and https://www.npmjs.com/search?q=scope:commitlint.