### PR TITLE
feat: add MDC Web monorepo preset

### DIFF
--- a/packages/renovate-config-group/package.json
+++ b/packages/renovate-config-group/package.json
@@ -111,6 +111,15 @@
         }
       ]
     },
+    "materialMonorepo": {
+      "packageRules": [
+        {
+          "description": "Group packages from material monorepo together",
+          "extends": "monorepo:material",
+          "groupName": "material monorepo"
+        }
+      ]
+    },
     "monorepos": {
       "description": "Group monorepo packages together",
       "extends": [
@@ -122,6 +131,7 @@
         "group:gatsbyMonorepo",
         "group:jestMonorepo",
         "group:lodashMonorepo",
+        "group:materialMonorepo",
         "group:neutrinoMonorepo",
         "group:ngrxMonorepo",
         "group:nrwlMonorepo",

--- a/packages/renovate-config-monorepo/generate.js
+++ b/packages/renovate-config-monorepo/generate.js
@@ -29,6 +29,9 @@ const staticSources = {
     packageNames: ['babel-plugin-lodash', 'lodash-webpack-plugin', 'lodash-es'],
     packagePatterns: ['^lodash'],
   },
+  material: {
+    packagePatterns: ['^@material/'],
+  },
   neutrino: {
     packageNames: ['neutrino'],
     packagePatterns: ['^@neutrinojs/'],

--- a/packages/renovate-config-monorepo/package.json
+++ b/packages/renovate-config-monorepo/package.json
@@ -416,6 +416,12 @@
         "^lodash"
       ]
     },
+    "material": {
+      "description": "material monorepo",
+      "packagePatterns": [
+        "^@material/"
+      ]
+    },
     "neutrino": {
       "description": "neutrino monorepo",
       "packageNames": [


### PR DESCRIPTION
This PR adds monorepo and group presets for the [MDC Web](https://github.com/material-components/material-components-web) monorepo, which contains [`@materials/`](https://www.npmjs.com/search?q=scope:material) packages.

Resolves #21.