### PR TITLE
Add Fimbullinter and TSLint related presets

### DIFF
--- a/packages/renovate-config-group/package.json
+++ b/packages/renovate-config-group/package.json
@@ -89,6 +89,15 @@
         }
       ]
     },
+    "fimbullinterMonorepo": {
+      "packageRules": [
+        {
+          "description": "Group packages from fimbullinter monorepo together",
+          "extends": "monorepo:fimbullinter",
+          "groupName": "fimbullinter monorepo"
+        }
+      ]
+    },
     "gatsbyMonorepo": {
       "packageRules": [
         {
@@ -143,6 +152,7 @@
         "group:babelMonorepo",
         "group:babel6Monorepo",
         "group:commitlintMonorepo",
+        "group:fimbullinterMonorepo",
         "group:gatsbyMonorepo",
         "group:jestMonorepo",
         "group:lodashMonorepo",

--- a/packages/renovate-config-monorepo/generate.js
+++ b/packages/renovate-config-monorepo/generate.js
@@ -44,6 +44,9 @@ const staticSources = {
   storybook: {
     packagePatterns: ['^@storybook/'],
   },
+  fimbullinter: {
+    packagePatterns: ['^@fimbul/'],
+  },
 };
 
 const dynamicSources = {

--- a/packages/renovate-config-monorepo/package.json
+++ b/packages/renovate-config-monorepo/package.json
@@ -293,6 +293,12 @@
         "^@commitlint/"
       ]
     },
+    "fimbullinter": {
+      "description": "fimbullinter monorepo",
+      "packagePatterns": [
+        "^@fimbul/"
+      ]
+    },
     "gatsby": {
       "description": "gatsby monorepo",
       "packageNames": [

--- a/packages/renovate-config-packages/package.json
+++ b/packages/renovate-config-packages/package.json
@@ -36,11 +36,22 @@
         "^stylelint"
       ]
     },
+    "tslint": {
+      "description": "All tslint packages",
+      "packageNames": [
+        "codelyzer"
+      ],
+      "packagePatterns": [
+        "(^|-)tslint(-|$)"
+      ]
+    },
     "linters": {
       "description": "All lint-related packages",
       "extends": [
         "packages:eslint",
-        "packages:stylelint"
+        "packages:stylelint",
+        "packages:tslint",
+        "monorepo:fimbullinter"
       ],
       "packageNames": [
         "remark-lint"


### PR DESCRIPTION
Add `monorepo:fimbullinter` for everything in the `@fimbul/` scope.
Ref: https://github.com/fimbullinter/wotan

Add `packages:tslint` that contains "tslint" at the beginning, the end or in the middle separated by a dash. That seems to cover all popular plugin packages with the exception of the one explicitly listed.
Ref: https://github.com/palantir/tslint#custom-rules--plugins

Added both to `packages:linters`.