### PR TITLE
generate.js: write package.json relative to script

### DIFF
--- a/packages/renovate-config-group/generate.js
+++ b/packages/renovate-config-group/generate.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const path = require('path');
 const pJson = require('./package.json');
 const staticGroups = require('./static-groups');
 const monorepos = require('../renovate-config-monorepo/package.json')[
@@ -32,7 +33,7 @@ async function go() {
   for (const rule of Object.keys(config).sort()) {
     pJson['renovate-config'][rule] = config[rule];
   }
-  fs.writeFileSync('package.json', `${JSON.stringify(pJson, null, 2)}\n`);
+  fs.writeFileSync(path.join(__dirname, 'package.json'), `${JSON.stringify(pJson, null, 2)}\n`);
 }
 
 go();

--- a/packages/renovate-config-monorepo/generate.js
+++ b/packages/renovate-config-monorepo/generate.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const got = require('gh-got');
+const path = require('path');
 const pJson = require('./package.json');
 
 const staticSources = {
@@ -117,7 +118,7 @@ async function go() {
   for (const rule of Object.keys(config).sort()) {
     pJson['renovate-config'][rule] = config[rule];
   }
-  fs.writeFileSync('package.json', `${JSON.stringify(pJson, null, 2)}\n`);
+  fs.writeFileSync(path.join(__dirname, 'package.json'), `${JSON.stringify(pJson, null, 2)}\n`);
 }
 
 go();


### PR DESCRIPTION
Allow executing the `generate.js` scripts from the monorepo root.
Before it has always overridden the root package.json.