### PR TITLE
fix pattern for tslint packages

### DIFF
--- a/packages/renovate-config-packages/package.json
+++ b/packages/renovate-config-packages/package.json
@@ -7,7 +7,7 @@
   "bugs": {
     "url": "https://github.com/singapore/renovate-config/issues"
   },
-  "version": "0.0.2",
+  "version": "0.0.3",
   "renovate-config": {
     "angularJs": {
       "description": "All angular.js packages",

--- a/packages/renovate-config-packages/package.json
+++ b/packages/renovate-config-packages/package.json
@@ -42,7 +42,7 @@
         "codelyzer"
       ],
       "packagePatterns": [
-        "(^|-)tslint(-|$)"
+        "\\btslint\\b"
       ]
     },
     "linters": {


### PR DESCRIPTION
This changes the pattern so that names like `@scope/tslint-config` are also matched.