### PR TITLE
Add prHourlyLimitNone preset.

### DIFF
--- a/packages/renovate-config-default/package.json
+++ b/packages/renovate-config-default/package.json
@@ -157,6 +157,10 @@
       "description": "Wait until branch tests have passed or failed before creating the PR",
       "prCreation": "not-pending"
     },
+    "prHourlyLimitNone": {
+      "description": "Removes rate limit for PR creation per hour",
+      "prHourlyLimit": 0
+    },
     "prHourlyLimit1": {
       "description": "Rate limit PR creation to a maximum of one per hour",
       "prHourlyLimit": 1


### PR DESCRIPTION
Preset to set `prHourlyLimit` back to the default of not having a limit.