### PR TITLE
 feat: add apolloclient monorepo

### DIFF
--- a/packages/renovate-config-group/package.json
+++ b/packages/renovate-config-group/package.json
@@ -7,7 +7,7 @@
   "bugs": {
     "url": "https://github.com/singapore/renovate-config/issues"
   },
-  "version": "0.7.0",
+  "version": "0.8.0",
   "renovate-config": {
     "accountsMonorepo": {
       "packageRules": [
@@ -73,6 +73,15 @@
           "description": "Group packages from angularmaterial monorepo together",
           "extends": "monorepo:angularmaterial",
           "groupName": "angularmaterial monorepo"
+        }
+      ]
+    },
+    "apolloclientMonorepo": {
+      "packageRules": [
+        {
+          "description": "Group packages from apolloclient monorepo together",
+          "extends": "monorepo:apolloclient",
+          "groupName": "apolloclient monorepo"
         }
       ]
     },
@@ -184,6 +193,7 @@
         "group:angularMonorepo",
         "group:angular1Monorepo",
         "group:angularmaterialMonorepo",
+        "group:apolloclientMonorepo",
         "group:babelMonorepo",
         "group:babel6Monorepo",
         "group:commitlintMonorepo",

--- a/packages/renovate-config-monorepo/generate.js
+++ b/packages/renovate-config-monorepo/generate.js
@@ -75,6 +75,10 @@ const dynamicSources = {
     repo: 'angular/angular',
     path: 'packages',
   },
+  apolloclient: {
+    repo: 'apollographql/apollo-client',
+    includePrivatePackage: true,
+  },
   babel6: {
     repo: 'babel/babel',
     branch: '6.x',
@@ -115,6 +119,7 @@ async function go() {
     const data = dynamicSources[monorepo];
     const branch = data.branch || 'master';
     const packagesPath = data.path || 'packages';
+    const includePrivatePackage = !!data.includePrivatePackage;
     const url = `https://api.github.com/repos/${
       data.repo
     }/contents/${packagesPath}`;
@@ -127,7 +132,10 @@ async function go() {
         }/${branch}/${packagesPath}/${item.name}/package.json`;
         try {
           const packageJson = (await got(packageJsonUrl)).body;
-          if (packageJson.name && packageJson.private !== true) {
+          if (
+            packageJson.name &&
+            (includePrivatePackage || packageJson.private !== true)
+          ) {
             packages.push(packageJson.name);
           }
         } catch (err) {

--- a/packages/renovate-config-monorepo/package.json
+++ b/packages/renovate-config-monorepo/package.json
@@ -7,7 +7,7 @@
   "bugs": {
     "url": "https://github.com/singapore/renovate-config/issues"
   },
-  "version": "0.9.1",
+  "version": "0.9.2",
   "renovate-config": {
     "accounts": {
       "description": "accounts monorepo",

--- a/packages/renovate-config-monorepo/package.json
+++ b/packages/renovate-config-monorepo/package.json
@@ -7,7 +7,7 @@
   "bugs": {
     "url": "https://github.com/singapore/renovate-config/issues"
   },
-  "version": "0.9.2",
+  "version": "0.10.0",
   "renovate-config": {
     "accounts": {
       "description": "accounts monorepo",
@@ -91,6 +91,17 @@
       "packageNames": [
         "@angular/material",
         "@angular/cdk"
+      ]
+    },
+    "apolloclient": {
+      "description": "apolloclient monorepo",
+      "packageNames": [
+        "apollo-boost",
+        "apollo-cache-inmemory",
+        "apollo-cache",
+        "apollo-client",
+        "apollo-utilities",
+        "graphql-anywhere"
       ]
     },
     "babel": {


### PR DESCRIPTION
apollo client monorepo [intentionally use `private: true`](https://github.com/apollographql/apollo-client/pull/3399#issuecomment-386751408) in their non-private packages, so I added `includePrivatePackage` support in monorepo/generate.js.