### PR TITLE
add :prConcurrentLimitNone

### DIFF
--- a/packages/renovate-config-default/package.json
+++ b/packages/renovate-config-default/package.json
@@ -196,6 +196,10 @@
       "description": "Rate limit PR creation to a maximum of four per hour",
       "prHourlyLimit": 4
     },
+    "prConcurrentLimitNone": {
+      "description": "Remove limit for concurrent Renovate PRs at any time",
+      "prConcurrentLimit": 0
+    },
     "prConcurrentLimit10": {
       "description": "Limit to maximum 10 concurrent Renovate PRs at any time",
       "prConcurrentLimit": 10

--- a/packages/renovate-config-default/package.json
+++ b/packages/renovate-config-default/package.json
@@ -11,7 +11,7 @@
   "bugs": {
     "url": "https://github.com/singapore/renovate-config/issues"
   },
-  "version": "0.6.4",
+  "version": "0.7.0",
   "renovate-config": {
     "enableRenovate": {
       "description": "Enable renovate",


### PR DESCRIPTION
PR adds this one. We use `config:base`, which sets it to 20, and want to remove it in a nicer looking way.