### PR TITLE
feat: added semantic-release as a monorepo entry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -181,8 +181,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -2579,8 +2578,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "isurl": {
       "version": "1.0.0",

--- a/packages/renovate-config-monorepo/generate.js
+++ b/packages/renovate-config-monorepo/generate.js
@@ -40,6 +40,10 @@ const staticSources = {
     packageNames: ['commitlint'],
     packagePatterns: ['^@commitlint/'],
   },
+  semanticrelease: {
+    packageNames: ['semantic-release'],
+    packagePatterns: ['^@semantic-release/'],
+  },
   lodash: {
     packageNames: ['babel-plugin-lodash', 'lodash-webpack-plugin', 'lodash-es'],
     packagePatterns: ['^lodash'],

--- a/packages/renovate-config-monorepo/package.json
+++ b/packages/renovate-config-monorepo/package.json
@@ -396,12 +396,14 @@
         "gatsby-plugin-emotion",
         "gatsby-plugin-facebook-analytics",
         "gatsby-plugin-feed",
+        "gatsby-plugin-flow",
         "gatsby-plugin-fullstory",
         "gatsby-plugin-glamor",
         "gatsby-plugin-google-analytics",
         "gatsby-plugin-google-tagmanager",
         "gatsby-plugin-guess-js",
         "gatsby-plugin-jss",
+        "gatsby-plugin-layout",
         "gatsby-plugin-less",
         "gatsby-plugin-lodash",
         "gatsby-plugin-manifest",
@@ -423,6 +425,7 @@
         "gatsby-plugin-styled-jsx",
         "gatsby-plugin-styletron",
         "gatsby-plugin-stylus",
+        "gatsby-plugin-subfont",
         "gatsby-plugin-twitter",
         "gatsby-plugin-typescript",
         "gatsby-plugin-typography",
@@ -432,6 +435,7 @@
         "gatsby-remark-copy-linked-files",
         "gatsby-remark-custom-blocks",
         "gatsby-remark-embed-snippet",
+        "gatsby-remark-graphviz",
         "gatsby-remark-images-contentful",
         "gatsby-remark-images",
         "gatsby-remark-katex",
@@ -544,6 +548,7 @@
         "@material/checkbox",
         "@material/chips",
         "@material/dialog",
+        "@material/dom",
         "@material/drawer",
         "@material/elevation",
         "@material/fab",
@@ -557,6 +562,7 @@
         "@material/line-ripple",
         "@material/linear-progress",
         "@material/list",
+        "@material/menu-surface",
         "@material/menu",
         "@material/notched-outline",
         "@material/radio",
@@ -664,6 +670,7 @@
         "react-reconciler",
         "react-test-renderer",
         "react",
+        "schedule",
         "simple-cache-provider"
       ]
     },
@@ -675,6 +682,15 @@
         "react-router-native",
         "react-router-redux",
         "react-router"
+      ]
+    },
+    "semanticrelease": {
+      "description": "semanticrelease monorepo",
+      "packageNames": [
+        "semantic-release"
+      ],
+      "packagePatterns": [
+        "^@semantic-release/"
       ]
     },
     "storybook": {


### PR DESCRIPTION
Closes #78.

I hope I did it right, I tried to follow the instructions, but since the sub packages don't have node modules I had to run `node generate.js` from the top level. Also, generating seemed to create more entries for some other stuff... so I guess that's good.