### PR TITLE
feat(config-monorepo): add baset to list of monorepo deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2535,8 +2535,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "isurl": {
       "version": "1.0.0",

--- a/packages/renovate-config-monorepo/generate.js
+++ b/packages/renovate-config-monorepo/generate.js
@@ -99,6 +99,9 @@ const dynamicSources = {
   babel: {
     repo: 'babel/babel',
   },
+  baset: {
+    repo: 'igmat/baset',
+  },
   emotion: {
     repo: 'emotion-js/emotion',
   },

--- a/packages/renovate-config-monorepo/package.json
+++ b/packages/renovate-config-monorepo/package.json
@@ -346,6 +346,23 @@
         "babel-types"
       ]
     },
+    "baset": {
+      "description": "baset monorepo",
+      "packageNames": [
+        "baset-baseliner-json",
+        "baset-baseliner-md",
+        "baset-cli",
+        "baset-core",
+        "baset-env-browser",
+        "baset-reader-babel",
+        "baset-reader-md",
+        "baset-reader-ts",
+        "baset-resolver-pixi",
+        "baset-resolver-react",
+        "baset-vm",
+        "baset"
+      ]
+    },
     "commitlint": {
       "description": "commitlint monorepo",
       "packageNames": [


### PR DESCRIPTION
I'm developer of [`BaseT`](https://github.com/Igmat/baset) testing tool and use [`lerna`](https://github.com/lerna/lerna) with `fixed mode` for managing monorepo, so it seems that it would be better if users of `renovate` will receive one PR instead of several for new releases of `BaseT`.