### PR TITLE
Group all packages by Font Awesome together

### DIFF
--- a/packages/renovate-config-group/package.json
+++ b/packages/renovate-config-group/package.json
@@ -7,7 +7,7 @@
   "bugs": {
     "url": "https://github.com/singapore/renovate-config/issues"
   },
-  "version": "0.23.0",
+  "version": "0.24.0",
   "renovate-config": {
     "accountsMonorepo": {
       "packageRules": [
@@ -175,6 +175,17 @@
           "description": "Group packages from fimbullinter monorepo together",
           "extends": "monorepo:fimbullinter",
           "groupName": "fimbullinter monorepo"
+        }
+      ]
+    },
+    "fortawesome": {
+      "description": "Group all packages by Font Awesome together",
+      "packageRules": [
+        {
+          "groupName": "fortawesome",
+          "packagePatterns": [
+            "^@fortawesome/"
+          ]
         }
       ]
     },
@@ -406,6 +417,7 @@
       "description": "Recommended groupings of packages, even if not published from same monorepo",
       "extends": [
         "group:allApollographql",
+        "group:fortawesome",
         "group:fusionjs",
         "group:polymer"
       ]

--- a/packages/renovate-config-group/package.json
+++ b/packages/renovate-config-group/package.json
@@ -182,7 +182,7 @@
       "description": "Group all packages by Font Awesome together",
       "packageRules": [
         {
-          "groupName": "fortawesome",
+          "groupName": "Fort Awesome",
           "packagePatterns": [
             "^@fortawesome/"
           ]

--- a/packages/renovate-config-group/static-groups.js
+++ b/packages/renovate-config-group/static-groups.js
@@ -30,7 +30,12 @@ module.exports = {
   recommended: {
     description:
       'Recommended groupings of packages, even if not published from same monorepo',
-    extends: ['group:allApollographql', 'group:fusionjs', 'group:polymer'],
+    extends: [
+      'group:allApollographql',
+      'group:fortawesome',
+      'group:fusionjs',
+      'group:polymer',
+    ],
   },
   allApollographql: {
     description: 'Group all packages published by Apollo GraphQL together',
@@ -47,6 +52,15 @@ module.exports = {
       {
         groupName: 'definitelyTyped',
         packagePatterns: ['^@types/'],
+      },
+    ],
+  },
+  fortawesome: {
+    description: 'Group all packages by Font Awesome together',
+    packageRules: [
+      {
+        groupName: 'fortawesome',
+        packagePatterns: ['^@fortawesome/'],
       },
     ],
   },

--- a/packages/renovate-config-group/static-groups.js
+++ b/packages/renovate-config-group/static-groups.js
@@ -59,7 +59,7 @@ module.exports = {
     description: 'Group all packages by Font Awesome together',
     packageRules: [
       {
-        groupName: 'fortawesome',
+        groupName: 'Fort Awesome',
         packagePatterns: ['^@fortawesome/'],
       },
     ],


### PR DESCRIPTION
We're relying on multiple repositories from @fortawesome, and they often update them in the same timeframe, Renovate then opening multiple PRs at the same time. Case in point, latest @fortawesome/fontawesome-svg-core and @fortawesome/free-solid-svg-icons were both released within a minute.

We haven't yet seen a hard dependency between these repos, making grouping mandatory, but it sure would be nice if those package upgrades were bundled together.

Related:

- https://github.com/renovatebot/presets/issues/46
- https://github.com/renovatebot/config-help/issues/38

Thoughts?