### PR TITLE
Add postcss group

### DIFF
--- a/packages/renovate-config-group/static-groups.js
+++ b/packages/renovate-config-group/static-groups.js
@@ -74,9 +74,9 @@ module.exports = {
     packageRules: [
       {
         extends: 'packages:postcss',
-        groupName: 'postcss packages'
-      }
-    ]
+        groupName: 'postcss packages',
+      },
+    ],
   },
   linters: {
     description: 'Group various lint packages together',

--- a/packages/renovate-config-group/static-groups.js
+++ b/packages/renovate-config-group/static-groups.js
@@ -69,6 +69,15 @@ module.exports = {
       },
     ],
   },
+  postcss: {
+    description: 'Group postcss packages together',
+    packageRules: [
+      {
+        extends: 'packages:postcss',
+        groupName: 'postcss packages'
+      }
+    ]
+  },
   linters: {
     description: 'Group various lint packages together',
     packageRules: [

--- a/packages/renovate-config-packages/package.json
+++ b/packages/renovate-config-packages/package.json
@@ -68,6 +68,15 @@
         "remark-lint"
       ]
     },
+    "postcss": {
+      "description": "All postcss packages",
+      "packageNames": [
+        "postcss"
+      ],
+      "packagePatterns": [
+        "^postcss-"
+      ]
+    },
     "jsUnitTest": {
       "description": "Unit test packages for javascript",
       "packageNames": [


### PR DESCRIPTION
Not quite complete, but covers the majority.

See https://github.com/postcss/postcss/blob/master/docs/plugins.md for the full list.

Will feed into https://github.com/Financial-Times/google-amp.