### PR TITLE
Rename "Fort Awesome" into "Font Awesome"

### DIFF
--- a/packages/renovate-config-group/package.json
+++ b/packages/renovate-config-group/package.json
@@ -7,7 +7,7 @@
   "bugs": {
     "url": "https://github.com/singapore/renovate-config/issues"
   },
-  "version": "0.24.0",
+  "version": "0.24.1",
   "renovate-config": {
     "accountsMonorepo": {
       "packageRules": [

--- a/packages/renovate-config-group/package.json
+++ b/packages/renovate-config-group/package.json
@@ -183,7 +183,6 @@
       "packageRules": [
         {
           "groupName": "Font Awesome",
-          "groupSlug": "fort-awesome",
           "packagePatterns": [
             "^@fortawesome/"
           ]

--- a/packages/renovate-config-group/package.json
+++ b/packages/renovate-config-group/package.json
@@ -182,7 +182,7 @@
       "description": "Group all packages by Font Awesome together",
       "packageRules": [
         {
-          "groupName": "Fort Awesome",
+          "groupName": "Font Awesome",
           "packagePatterns": [
             "^@fortawesome/"
           ]

--- a/packages/renovate-config-group/package.json
+++ b/packages/renovate-config-group/package.json
@@ -183,6 +183,7 @@
       "packageRules": [
         {
           "groupName": "Font Awesome",
+          "groupSlug": "fort-awesome",
           "packagePatterns": [
             "^@fortawesome/"
           ]

--- a/packages/renovate-config-group/static-groups.js
+++ b/packages/renovate-config-group/static-groups.js
@@ -59,7 +59,7 @@ module.exports = {
     description: 'Group all packages by Font Awesome together',
     packageRules: [
       {
-        groupName: 'Fort Awesome',
+        groupName: 'Font Awesome',
         packagePatterns: ['^@fortawesome/'],
       },
     ],


### PR DESCRIPTION
Teeny tiny change, but the fort/font difference is rather confusing, and at the moment Renovate opens PRs titled "Update Fort Awesome" (but hey, it works, thanks for merging #87!) which I know for a fact that I will always miss when I grep/search :D