### PR TITLE
feat(config-monorepo): Add aws-cdk monorepo

### DIFF
--- a/packages/renovate-config-monorepo/generate.js
+++ b/packages/renovate-config-monorepo/generate.js
@@ -36,6 +36,10 @@ const staticSources = {
       '@types/angular-touch',
     ],
   },
+  'aws-cdk': {
+    packageNames: ['aws-cdk', 'decdk', 'simple-resource-bundler'],
+    packagePatterns: ['^@aws-cdk/'],
+  },
   commitlint: {
     packageNames: ['commitlint'],
     packagePatterns: ['^@commitlint/'],


### PR DESCRIPTION
Overview
--------

aws-cdk is a library for creating AWS CloudFormation templates.  See https://github.com/awslabs/aws-cdk/tree/master/packages