### PR TITLE
Added should to jsUnitTest

### DIFF
--- a/packages/renovate-config-packages/package.json
+++ b/packages/renovate-config-packages/package.json
@@ -91,7 +91,8 @@
       ],
       "packagePatterns": [
         "^chai",
-        "^sinon"
+        "^sinon",
+        "^should"
       ]
     },
     "unitTest": {


### PR DESCRIPTION
This is an opinionated change I think maybe? There are many many assertion libraries out there, I know chai is most popular. At Ghost we use should, and we use renovate. Would be awesome if the standard `group:jsTestMonMajor` config preset understood that `should` belongs with mocha and sinon.

- should is an assertions library similar to chai: https://www.npmjs.com/package/should