### PR TITLE
feat: add remark to monorepos

### DIFF
--- a/packages/renovate-config-monorepo/generate.js
+++ b/packages/renovate-config-monorepo/generate.js
@@ -203,6 +203,9 @@ const staticSources = {
   lerna: {
     sourceUrlPrefixes: ['https://github.com/lerna/lerna'],
   },
+  remark: {
+    sourceUrlPrefixes: ['https://github.com/remarkjs/remark'],
+  },
   'electron-forge': {
     sourceUrlPrefixes: ['https://github.com/electron-userland/electron-forge'],
   },

--- a/packages/renovate-config-monorepo/package.json
+++ b/packages/renovate-config-monorepo/package.json
@@ -970,12 +970,6 @@
         "react-router"
       ]
     },
-    "remark": {
-      "description": "remark monorepo",
-      "sourceUrlPrefixes": [
-        "https://github.com/remarkjs/remark"
-      ]
-    },
     "router5": {
       "description": "router5 monorepo",
       "sourceUrlPrefixes": [

--- a/packages/renovate-config-monorepo/package.json
+++ b/packages/renovate-config-monorepo/package.json
@@ -970,6 +970,12 @@
         "react-router"
       ]
     },
+    "remark": {
+      "description": "remark monorepo",
+      "sourceUrlPrefixes": [
+        "https://github.com/remarkjs/remark"
+      ]
+    },
     "router5": {
       "description": "router5 monorepo",
       "sourceUrlPrefixes": [


### PR DESCRIPTION
Adds https://github.com/remarkjs/remark as a monorepo for all the linting rules and such that are tied to using remark.