### PR TITLE
[fix]: typo - inluding => including

### DIFF
--- a/packages/renovate-config-default/package.json
+++ b/packages/renovate-config-default/package.json
@@ -276,11 +276,11 @@
       }
     },
     "automergeMajor": {
-      "description": "Automerge all upgrades (inluding major) if they pass tests",
+      "description": "Automerge all upgrades (including major) if they pass tests",
       "automerge": true
     },
     "automergeAll": {
-      "description": "Automerge all upgrades (inluding major) if they pass tests",
+      "description": "Automerge all upgrades (including major) if they pass tests",
       "automerge": true
     },
     "automergeBranchMergeCommit": {


### PR DESCRIPTION
See https://twitter.com/rickydelaveaga/status/1152524575386697729

> @renovatebot I looked on https://github.com/renovatebot but it does not seem like docs are open source? Here is a typo:
> inluding => including
> …occurs twice, once in:
> https://renovatebot.com/docs/presets-default/#automergemajor
> …and once in:
> https://renovatebot.com/docs/presets-default/#automergeall https://twitter.com/rickydelaveaga/status/1152524575386697729/photo/1