### PR TITLE
Update sourceUrlPrefixes for monorepo:storybook preset

### DIFF
--- a/packages/renovate-config-monorepo/generate.js
+++ b/packages/renovate-config-monorepo/generate.js
@@ -73,7 +73,7 @@ const repoGroups = {
   remark: 'https://github.com/remarkjs/remark',
   router5: 'https://github.com/router5/router5',
   sentry: 'https://github.com/getsentry/sentry-javascript',
-  storybook: 'https://github.com/storybooks',
+  storybook: 'https://github.com/storybookjs/storybook',
   strapi: 'https://github.com/strapi/strapi',
   stryker: 'https://github.com/stryker-mutator/stryker',
   surveyjs: 'https://github.com/surveyjs/surveyjs',

--- a/packages/renovate-config-monorepo/package.json
+++ b/packages/renovate-config-monorepo/package.json
@@ -392,7 +392,7 @@
     "storybook": {
       "description": "storybook monorepo",
       "sourceUrlPrefixes": [
-        "https://github.com/storybooks"
+        "https://github.com/storybookjs/storybook"
       ]
     },
     "strapi": {


### PR DESCRIPTION
From what I can tell, at one point, the [Storybook project](https://storybook.js.org/) was under the `storybooks` github user, but that user has been removed/renamed to `storybookjs`. The storybook monorepo can be found [here](https://github.com/storybookjs/storybook), so the `sourceUrlPrefixes` just needed to be fixed.