### PR TITLE
Add "babel-eslint" to "packages:eslint" group

### DIFF
--- a/packages/renovate-config-packages/package.json
+++ b/packages/renovate-config-packages/package.json
@@ -30,6 +30,9 @@
     },
     "eslint": {
       "description": "All eslint packages",
+      "packageNames": [
+        "babel-eslint"
+      ],
       "packagePatterns": [
         "^eslint"
       ]


### PR DESCRIPTION
This adds the package `babel-eslint` to the `eslint` group in the `renovate-config-packages` group, so that it is available in the `packages:linters` group.