### PR TITLE
Add ":automergeTypes" default preset to enable automerge for @types/

### DIFF
--- a/packages/renovate-config-default/package.json
+++ b/packages/renovate-config-default/package.json
@@ -354,6 +354,17 @@
         }
       ]
     },
+    "automergeTypes": {
+      "description": "Update @types/* packages automatically if tests pass",
+      "packageRules": [
+        {
+          "packagePatterns": [
+            "^@types/"
+          ],
+          "automerge": true
+        }
+      ]
+    },
     "doNotPinPackage": {
       "description": "Disable version pinning for <code>{{arg0}}</code>",
       "packageRules": [


### PR DESCRIPTION
Similar to `:automergeLinters`, this PR adds a new preset called
`:automergeTypes` in order to automatically merge `@types/*`
dependencies.