### PR TITLE
Add :automergeBranch preset

### DIFF
--- a/packages/renovate-config-default/package.json
+++ b/packages/renovate-config-default/package.json
@@ -293,11 +293,11 @@
       "automergeType": "branch"
     },
     "automergeBranchMergeCommit": {
-      "description": "If automerging, perform a merge-commit on branch (no PR)",
+      "description": "If automerging, perform a merge-commit on branch (no PR) - deprecated, use :automergeBranch instead",
       "automergeType": "branch-merge-commit"
     },
     "automergeBranchPush": {
-      "description": "If automerging, push the new commit directly to base branch (no PR)",
+      "description": "If automerging, push the new commit directly to base branch (no PR) - deprecated, use :automergeBranch instead",
       "automergeType": "branch-push"
     },
     "automergePr": {

--- a/packages/renovate-config-default/package.json
+++ b/packages/renovate-config-default/package.json
@@ -288,6 +288,10 @@
       "description": "Automerge all upgrades (including major) if they pass tests",
       "automerge": true
     },
+    "automergeBranch": {
+      "description": "If automerging, push the new commit directly to base branch (no PR)",
+      "automergeType": "branch"
+    },
     "automergeBranchMergeCommit": {
       "description": "If automerging, perform a merge-commit on branch (no PR)",
       "automergeType": "branch-merge-commit"


### PR DESCRIPTION
I'd like to add an `:automergeBranch` preset. I guess the documentation will be updated/generated automatically?

There are existing `:automergeBranchMergeCommit` and `:automergeBranchPush` presets. Should they be
* kept (current state of the PR)
* have *(deprecated)* added to their description
* removed?

I enjoy using renovate bot! Thanks for creating and maintaining it!