### PR TITLE
feat: add `pinDependencies` and `pinDevDependencies` presets

### DIFF
--- a/packages/renovate-config-default/package.json
+++ b/packages/renovate-config-default/package.json
@@ -69,6 +69,17 @@
         }
       ]
     },
+    "pinDependencies": {
+      "description": "Pin dependency versions for <code>dependencies</code>",
+      "packageRules": [
+        {
+          "depTypeList": [
+            "dependencies"
+          ],
+          "rangeStrategy": "pin"
+        }
+      ]
+    },
     "pinDevDependencies": {
       "description": "Pin dependency versions for <code>devDependencies</code>",
       "packageRules": [

--- a/packages/renovate-config-default/package.json
+++ b/packages/renovate-config-default/package.json
@@ -69,6 +69,17 @@
         }
       ]
     },
+    "pinDevDependencies": {
+      "description": "Pin dependency versions for <code>devDependencies</code>",
+      "packageRules": [
+        {
+          "depTypeList": [
+            "devDependencies"
+          ],
+          "rangeStrategy": "pin"
+        }
+      ]
+    },
     "pinOnlyDevDependencies": {
       "description": "Pin dependency versions for <code>devDependencies</code> and retain semver ranges for others",
       "packageRules": [


### PR DESCRIPTION
These presets are similar to but more than generic (and thus more useful hopefully) than some of the existing presets like `pinOnlyDevDependencies`.