### PR TITLE
feat(monorepo): add ngx-formly

### DIFF
--- a/packages/renovate-config-group/package.json
+++ b/packages/renovate-config-group/package.json
@@ -687,6 +687,7 @@
         "group:neutrinoMonorepo",
         "group:nextjsMonorepo",
         "group:ngrxMonorepo",
+        "group:ngx-formlyMonorepo",
         "group:ngxs-storeMonorepo",
         "group:nrwlMonorepo",
         "group:nuxtjsMonorepo",
@@ -761,6 +762,15 @@
           "description": "Group packages from ngrx monorepo together",
           "extends": "monorepo:ngrx",
           "groupName": "ngrx monorepo"
+        }
+      ]
+    },
+    "ngx-formlyMonorepo": {
+      "packageRules": [
+        {
+          "description": "Group packages from ngx-formly monorepo together",
+          "extends": "monorepo:ngx-formly",
+          "groupName": "ngx-formly monorepo"
         }
       ]
     },

--- a/packages/renovate-config-monorepo/generate.js
+++ b/packages/renovate-config-monorepo/generate.js
@@ -22,6 +22,7 @@ const repoGroups = {
   'graphql-modules': 'https://github.com/Urigo/graphql-modules',
   'ionic-native': 'https://github.com/ionic-team/ionic-native',
   'mdc-react': 'material-components/material-components-web-react',
+  'ngx-formly': 'https://github.com/ngx-formly/ngx-formly',
   'ngxs-store': 'https://github.com/ngxs/store',
   'react-dnd': 'https://github.com/react-dnd/react-dnd',
   'reactivestack-cookies': 'https://github.com/reactivestack/cookies',

--- a/packages/renovate-config-monorepo/package.json
+++ b/packages/renovate-config-monorepo/package.json
@@ -318,6 +318,12 @@
         "https://github.com/ngrx/"
       ]
     },
+    "ngx-formly": {
+      "description": "ngx-formly monorepo",
+      "sourceUrlPrefixes": [
+        "https://github.com/ngx-formly/ngx-formly"
+      ]
+    },
     "ngxs-store": {
       "description": "ngxs-store monorepo",
       "sourceUrlPrefixes": [


### PR DESCRIPTION
It would be great if we could add support for [ngx-formly](https://github.com/ngx-formly/ngx-formly) so it updates the deps in a single PR.