### PR TITLE
Added GraphQL-Toolkit monorepo preset

### DIFF
--- a/packages/renovate-config-monorepo/generate.js
+++ b/packages/renovate-config-monorepo/generate.js
@@ -48,10 +48,11 @@ const repoGroups = {
   flopflip: 'https://github.com/tdeekens/flopflip',
   framework7: 'https://github.com/framework7io/framework7',
   gatsby: 'https://github.com/gatsbyjs/gatsby',
-  graphqlcodegenerator: [
+  'graphql-code-generator': [
     'https://github.com/dotansimha/graphql-code-generator',
     'https://github.com/dotansimha/graphql-codegen',
   ],
+  'graphql-toolkit': 'https://github.com/ardatan/graphql-toolkit',
   hapijs: 'https://github.com/hapijs',
   infrastructure: 'https://github.com/instructure/instructure-ui',
   jest: 'https://github.com/facebook/jest',

--- a/packages/renovate-config-monorepo/generate.js
+++ b/packages/renovate-config-monorepo/generate.js
@@ -48,7 +48,7 @@ const repoGroups = {
   flopflip: 'https://github.com/tdeekens/flopflip',
   framework7: 'https://github.com/framework7io/framework7',
   gatsby: 'https://github.com/gatsbyjs/gatsby',
-  'graphql-code-generator': [
+  graphqlcodegenerator: [
     'https://github.com/dotansimha/graphql-code-generator',
     'https://github.com/dotansimha/graphql-codegen',
   ],

--- a/packages/renovate-config-monorepo/package.json
+++ b/packages/renovate-config-monorepo/package.json
@@ -220,6 +220,12 @@
         "https://github.com/Urigo/graphql-modules"
       ]
     },
+    "graphql-toolkit": {
+      "description": "graphql-toolkit monorepo",
+      "sourceUrlPrefixes": [
+        "https://github.com/ardatan/graphql-toolkit"
+      ]
+    },
     "graphqlcodegenerator": {
       "description": "graphqlcodegenerator monorepo",
       "sourceUrlPrefixes": [


### PR DESCRIPTION
Continue from: https://github.com/renovatebot/presets/pull/150 , with fixes as suggested by @rarkins 

Also, updated `graphql-code-generator` to the correct name form. 