### PR TITLE
Add pollyjs monorepo

### DIFF
--- a/packages/renovate-config-group/package.json
+++ b/packages/renovate-config-group/package.json
@@ -691,6 +691,7 @@
         "group:nrwlMonorepo",
         "group:nuxtjsMonorepo",
         "group:picassoMonorepo",
+        "group:pollyjsMonorepo",
         "group:pouchdbMonorepo",
         "group:reactMonorepo",
         "group:react-dndMonorepo",
@@ -797,6 +798,15 @@
           "description": "Group packages from picasso monorepo together",
           "extends": "monorepo:picasso",
           "groupName": "picasso monorepo"
+        }
+      ]
+    },
+    "pollyjsMonorepo": {
+      "packageRules": [
+        {
+          "description": "Group packages from pollyjs monorepo together",
+          "extends": "monorepo:pollyjs",
+          "groupName": "pollyjs monorepo"
         }
       ]
     },

--- a/packages/renovate-config-monorepo/generate.js
+++ b/packages/renovate-config-monorepo/generate.js
@@ -72,6 +72,7 @@ const repoGroups = {
   nrwl: 'https://github.com/nrwl/',
   nuxtjs: 'https://github.com/nuxt/nuxt.js',
   picasso: 'https://github.com/qlik-oss/picasso.js',
+  pollyjs: 'https://github.com/Netflix/pollyjs',
   pouchdb: 'https://github.com/pouchdb/pouchdb',
   react: 'https://github.com/facebook/react',
   reactrouter: 'https://github.com/ReactTraining/react-router',

--- a/packages/renovate-config-monorepo/package.json
+++ b/packages/renovate-config-monorepo/package.json
@@ -348,6 +348,12 @@
         "https://github.com/qlik-oss/picasso.js"
       ]
     },
+    "pollyjs": {
+      "description": "pollyjs monorepo",
+      "sourceUrlPrefixes": [
+        "https://github.com/Netflix/pollyjs"
+      ]
+    },
     "pouchdb": {
       "description": "pouchdb monorepo",
       "sourceUrlPrefixes": [


### PR DESCRIPTION
Currently, I'm grouping the [Polly.JS](https://github.com/Netflix/pollyjs) monorepo in my own Renovate config. It'd be nice to have it centralised 🙂 