### PR TITLE
feat: ignore __fixtures__

### DIFF
--- a/packages/renovate-config-default/package.json
+++ b/packages/renovate-config-default/package.json
@@ -36,7 +36,8 @@
         "**/examples/**",
         "**/__tests__/**",
         "**/test/**",
-        "**/tests/**"
+        "**/tests/**",
+        "**/__fixtures__/**"
       ]
     },
     "includeNodeModules": {


### PR DESCRIPTION
We should ignore fixtures by default config.

ref: renovatebot/renovate#5373