### PR TITLE
Provide monorepo for Dropwizard

### DIFF
--- a/packages/renovate-config-monorepo/generate.js
+++ b/packages/renovate-config-monorepo/generate.js
@@ -42,6 +42,7 @@ const repoGroups = {
   capacitor: 'https://github.com/ionic-team/capacitor',
   clarity: 'https://github.com/vmware/clarity',
   commitlint: 'https://github.com/conventional-changelog/commitlint',
+  dropwizard: 'https://github.com/dropwizard/dropwizard',
   emotion: 'https://github.com/emotion-js/emotion',
   expo: 'https://github.com/expo/expo',
   fimbullinter: 'https://github.com/fimbullinter/wotan',


### PR DESCRIPTION
I'm running into https://github.com/renovatebot/presets/issues/170 locally and can't generate the package.json changes needed. I can manually add the needed data to be able to create a monorepo for [dropwizard](https://github.com/dropwizard/dropwizard) if absolutely needed.